### PR TITLE
Fix fonts and unscoped image variable

### DIFF
--- a/CSS/home.css
+++ b/CSS/home.css
@@ -26,8 +26,8 @@ html,body{
     height: 10%;
     color: antiquewhite;
     background-color: transparent;
-    font-family: 'Autowide';
-    font-weight: 100%;
+    font-family: 'Audiowide';
+    font-weight: 100;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -44,7 +44,7 @@ html,body{
     width: 50%;
     color: antiquewhite;
     font-family: 'Audiowide';
-    font-weight: 100%;
+    font-weight: 100;
     text-align: center;
 }
 #centre h1{
@@ -64,6 +64,6 @@ html,body{
     margin-top: 2%;
     height: 5%;
     width: 25%;
-    font-family: 'Audiwide';
+    font-family: 'Audiowide';
 }
 

--- a/JS/imageLoader.js
+++ b/JS/imageLoader.js
@@ -1,6 +1,6 @@
 var bounds = JSON.parse(localStorage.getItem("bounds"));
 
-src = "https://api.mapbox.com/styles/v1/mapbox/satellite-v9/static/"+bounds[0]+","+bounds[1]+","+bounds[2]+",0/500x400?access_token=pk.eyJ1IjoiYnJhdmVzdG9uZTkiLCJhIjoiY2tybHpxb2NvMGk0YTJwbm96eHFrZ3lhZCJ9.XC7Aw273nUmc9uzoKveEiA"
+const src = "https://api.mapbox.com/styles/v1/mapbox/satellite-v9/static/"+bounds[0]+","+bounds[1]+","+bounds[2]+",0/500x400?access_token=pk.eyJ1IjoiYnJhdmVzdG9uZTkiLCJhIjoiY2tybHpxb2NvMGk0YTJwbm96eHFrZ3lhZCJ9.XC7Aw273nUmc9uzoKveEiA";
 
 console.log(bounds)
 console.log(src)


### PR DESCRIPTION
## Summary
- fix typos in Google Font name
- use numeric font-weight instead of percentage
- declare `src` constant in the image loader script

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6873b28915d8832b8221cee5b3939e3c